### PR TITLE
fix: Support cases where request body is a Buffer

### DIFF
--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -233,7 +233,7 @@ export function frontegg(options: IFronteggOptions) {
     }
 
     if (req.body) {
-      const bodyData = JSON.stringify(req.body);
+      const bodyData = Buffer.isBuffer(req.body) ? req.body : JSON.stringify(req.body);
       // in case if content-type is application/x-www-form-urlencoded -> we need to change to application/json
       proxyReq.setHeader('Content-Type', 'application/json');
       proxyReq.setHeader('Content-Length', Buffer.byteLength(bodyData));


### PR DESCRIPTION
When using `serverless-http` to run the api-proxy in AWS Lambda, the
request body is held in a Buffer. This was causing a bad request because
the Buffer needs to be passed along, instead of turned in to a JSON
string.

The call to `proxyReq.write` uses Node's `stream.Writeable` class:
https://nodejs.org/api/stream.html#stream_writable_write_chunk_encoding_callback
supports writing a Buffer as a chunk.