### PR TITLE
export ContextHolder

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,7 +2,7 @@ import { AuditsClient } from './src/audits';
 import { IdentityClient } from './src/identity';
 import { FronteggAuthenticator } from './src/authenticator';
 import { contextResolver, withAuthentication } from './src/identity';
-import { frontegg, fronteggNextJs, IFronteggOptions } from './src/middleware';
+import { frontegg, fronteggNextJs, IFronteggOptions, ContextHolder } from './src/middleware';
 import { NotificationsClient } from './src/notifications';
 import { FronteggPermissions } from './src/permissions';
 import { RbacMiddleware } from './src/rbac';
@@ -13,6 +13,7 @@ export * from './src/events';
 
 export {
   AuditsClient,
+  ContextHolder
   NotificationsClient,
   TenantsClient,
   frontegg,


### PR DESCRIPTION
using the ContextHolder we can preset the clientId and apiKey instead of having to put them as env varibles.